### PR TITLE
Meal追加2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
 
   postgres:
     container_name: go_meal_record_postgres
-    image: postgres:alpine
+    build:
+      context: .
+      dockerfile: ./postgres/Dockerfile
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,0 +1,1 @@
+FROM postgres:alpine


### PR DESCRIPTION
postgres dockerfile作成。
aws ECRはDockerfileごとにimageを作る必要があるため。
全てdickerfileを用意